### PR TITLE
Set HTTP status code to 404 when using custom url for not found page

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -634,6 +634,7 @@ class toxidCurl
                 break;
             case 404:
                 if($this->_getToxidNotFoundUrl() && !$notFound404) {
+                    header("HTTP/1.0 404 Not Found");
                     $aPage = $this->getRemoteContentAndHandleStatusCodes($this->_getToxidNotFoundUrl(), true);
                     break;
                 }


### PR DESCRIPTION
In some cases we use custom URL to behave as 404 page. However, the HTTP status comes as 200, so we have to modify it to 404.